### PR TITLE
refactor(intercptor): use rxjs instead of promises

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5106,7 +5106,6 @@
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
       "integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
-      "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -6007,8 +6006,7 @@
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
-      "dev": true
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
     },
     "tslint": {
       "version": "5.16.0",

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -34,7 +34,7 @@ describe('AppController (e2e)', () => {
       // tslint:disable-next-line: quotemark
       .expect("cookie1 set to 'Hello World!', cookie2 set to 'c2 value'")
       .expect(res => {
-        expect(res.header['set-cookie']).toHaveLength(1);
+        expect(res.header['set-cookie']).toHaveLength(2);
         saveCookie1 = res.header['set-cookie'].find(
           (cookie: string) => cookie.includes('cookie1'),
         );


### PR DESCRIPTION
Super quick update to the code to change the interceptor from running `toPromise` and the relative code afterwards to using the `.pipe` method and `tap` operator. Everything runs as expected.

Fix: #3 