### PR TITLE
fix: move index to src instead of root

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,1 +1,0 @@
-export * from './dist';

--- a/index.js
+++ b/index.js
@@ -1,6 +1,0 @@
-"use strict";
-function __export(m) {
-    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
-}
-exports.__esModule = true;
-__export(require("./dist"));

--- a/index.ts
+++ b/index.ts
@@ -1,1 +1,0 @@
-export * from './dist';

--- a/package-lock.json
+++ b/package-lock.json
@@ -663,9 +663,9 @@
       }
     },
     "acorn": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-      "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+      "version": "5.7.4",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+      "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
       "dev": true
     },
     "acorn-globals": {
@@ -679,9 +679,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
-          "integrity": "sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q==",
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+          "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
           "dev": true
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3999,9 +3999,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "lodash.sortby": {
       "version": "4.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4364,9 +4364,9 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
       "dev": true
     },
     "node-int64": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestjsplus/cookies",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,9 +5,13 @@
   "author": "John Biundo <johnfbiundo@gmail.com>",
   "license": "MIT",
   "readmeFilename": "README.md",
+  "files": [
+    "dist"
+  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
-    "build": "rm -rf ./dist && tsc && npm run build:index",
-    "build:index": "rm -rf ./index.js ./index.d.ts && tsc -d --skipLibCheck ./index.ts",
+    "build": "rimraf ./dist && tsc -p tsconfig.build.json",
     "format": "prettier --write \"src/**/*.ts\"",
     "lint": "tslint -p tsconfig.json -c tslint.json",
     "test": "jest",

--- a/src/interceptors/clear-cookies.interceptor.ts
+++ b/src/interceptors/clear-cookies.interceptor.ts
@@ -1,12 +1,12 @@
 import 'reflect-metadata';
 import {
+  CallHandler,
+  ExecutionContext,
   Injectable,
   NestInterceptor,
-  ExecutionContext,
-  CallHandler,
 } from '@nestjs/common';
-import { Observable } from 'rxjs';
 import { Response } from 'express';
+import { Observable } from 'rxjs';
 
 @Injectable()
 export class ClearCookiesInterceptor implements NestInterceptor {

--- a/src/interceptors/set-cookies.interceptor.ts
+++ b/src/interceptors/set-cookies.interceptor.ts
@@ -3,14 +3,14 @@ import unionBy = require('lodash/unionBy');
 import { CookieSettings } from '../interfaces';
 
 import {
+  CallHandler,
+  ExecutionContext,
   Injectable,
   NestInterceptor,
-  ExecutionContext,
-  CallHandler,
 } from '@nestjs/common';
+import { Response } from 'express';
 import { Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
-import { Response } from 'express';
 
 @Injectable()
 export class SetCookiesInterceptor implements NestInterceptor {

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -1,8 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import * as CookieParser from 'cookie-parser';
+import { join } from 'path';
 import * as request from 'supertest';
 import { AppModule } from './src/app.module';
-import { join } from 'path';
-import * as CookieParser from 'cookie-parser';
 
 let agent;
 
@@ -28,7 +28,7 @@ describe('AppController (e2e)', () => {
   });
 
   it('/set should set cookie1, cookie2', async () => {
-    return await agent
+    return agent
       .get('/set')
       .expect(200)
       // tslint:disable-next-line: quotemark
@@ -49,7 +49,7 @@ describe('AppController (e2e)', () => {
   });
 
   it('/cookieSet1 should set cookie3, cookie4', async () => {
-    return await agent
+    return agent
       .get('/cookieSet1')
       .expect(200)
       .expect(res => {
@@ -65,7 +65,7 @@ describe('AppController (e2e)', () => {
   });
 
   it('/cookieSet2 should set cookie1, cookie3, cookie4', async () => {
-    return await agent
+    return agent
       .get('/cookieSet2')
       .expect(200)
       .expect(res => {
@@ -85,7 +85,7 @@ describe('AppController (e2e)', () => {
   });
 
   it('/cookieSet3 should override cookie3, set cookie4', async () => {
-    return await agent
+    return agent
       .get('/cookieSet3')
       .expect(200)
       .expect(res => {
@@ -101,7 +101,7 @@ describe('AppController (e2e)', () => {
   });
 
   it('/cookieSet4 should set cookie3, cookie4 with httpOnly', async () => {
-    return await agent
+    return agent
       .get('/cookieSet4')
       .expect(200)
       .expect(res => {
@@ -124,7 +124,7 @@ describe('AppController (e2e)', () => {
     const testCookieHeader = `${testCookieName}=${testCookieVal}`;
     const testCookieResponse = {};
     testCookieResponse[testCookieName] = testCookieVal;
-    return await agent
+    return agent
       .get('/dget')
       .set('cookie', testCookieHeader)
       .expect(200)
@@ -132,7 +132,7 @@ describe('AppController (e2e)', () => {
   });
 
   it('/sget should get signed cookie sent', async () => {
-    return await agent
+    return agent
       .get('/sget')
       .set('cookie', saveCookie1)
       .expect(200)
@@ -140,7 +140,7 @@ describe('AppController (e2e)', () => {
   });
 
   it('/defaults should set def1, def2 cookies', async () => {
-    return await agent
+    return agent
       .get('/defaults')
       .expect(200)
       // tslint:disable-next-line: quotemark
@@ -156,7 +156,7 @@ describe('AppController (e2e)', () => {
   });
 
   it('/clear should clear cookie1, render response', async () => {
-    return await agent
+    return agent
       .get('/clear')
       .expect(200)
       .expect(res => {

--- a/test/src/app.controller.ts
+++ b/test/src/app.controller.ts
@@ -2,17 +2,17 @@ import {
   Controller,
   Get,
   Headers,
-  Request,
   Query,
   Render,
+  Request,
 } from '@nestjs/common';
 import {
-  SetCookies,
   ClearCookies,
   Cookies,
+  CookieSettings,
+  SetCookies,
   SignedCookies,
-} from '../../src/decorators';
-import { CookieSettings } from '../../src/interfaces';
+} from '../../src';
 
 const tcookies: CookieSettings[] = [
   { name: 'cookie3', value: 'cookie3 value' },

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,7 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src"
+  },
   "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,10 +8,10 @@
     "target": "es6",
     "sourceMap": false,
     "outDir": "./dist",
-    "rootDir": "./src",
+    "rootDir": "./",
     "baseUrl": "./",
     "noLib": false
   },
-  "include": ["*.ts", "**/*.ts"],
-  "exclude": ["./index.ts", "./index.d.ts", "node_modules", "test"]
+  "include": ["src", "test"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
chore: clean up imports and configs

I have a preference of having my imports alphabetized by package name.
You're absolutely welcome to ask me to revert those changes, it's just
a preference of mine. I updated the build command to use the specific
`tsconfig.build.json` that will allow for the base `tsconfig.json` to
reference all ts files, while the build one only references the `src`
directory. Also switched out `rm -rf` for `rimraf` to take into account
those who may be on windows (and as the package was already installed).
All tests still pass, and the Node REPL pulls in the correct functions
when using `require('./')`.

fix #9 