### PR TITLE
adding @SetCookies annotation to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ the `request` object, so you must bind `@Request()` to a route parameter.
     <br/>For example:
 
 ```typescript
+@SetCookies()
 set(@Request() req) {
   const cookie1Value = 'chocoloate chip';
   req._cookies = [


### PR DESCRIPTION
Hey,

so I tried your project and noticed that the README can be a bit confusing for the dynamic setting of cookies. I think it should be specified that the `@SetCookies` decorator is also needed in the dynamic case but without any arguments.