### PR TITLE
adding two interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Reading **signed cookies** requires that the `CookieParser` be configured with a
 Use the `@Cookies()` route parameter decorator to get "regular" cookies.
 ```typescript
 @Get('get')
-get(@Cookies() cookies): string {
+get(@Cookies() cookies: CookiesObject): string {
   console.log('cookies: ', cookies);
   return this.appService.getHello();
 }
@@ -151,7 +151,7 @@ the `request` object, so you must bind `@Request()` to a route parameter.
     <br/>For example:
 
 ```typescript
-set(@Request() req) {
+set(@Request() req: CookieWritingRequest) {
   const cookie1Value = 'chocoloate chip';
   req._cookies = [
     {

--- a/src/interfaces/cookies.interfaces.ts
+++ b/src/interfaces/cookies.interfaces.ts
@@ -60,3 +60,11 @@ export interface CookieSettings {
    */
   options?: CookieOptions;
 }
+
+export interface CookiesObject {
+  [name: string]: string;
+}
+
+export interface CookieWritingRequest {
+  _cookies: CookieSettings[];
+}


### PR DESCRIPTION
I have found those two interfaces somewhat useful and mandatory since we do want to use TypeScript and so any is not an option. Maybe one could also think about adding an interface for reading cookies from the request object, but I guess that is somewhat discouraged by the `@Cookies` decorator. 